### PR TITLE
Fix: Use a regular expression instead of a naive todo search

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,7 +83,7 @@ def checktodo_main():
             elif current_file is not None \
                     and current_pos is not None \
                     and line.startswith('+'):
-                if re.match(r'[^\w\d]todo[^\w\d]', line.lower()):
+                if re.match(r'[^\w\d]todo(?![\w\d])', line.lower()):
                     added.append({
                         'line': current_pos,
                         'file': current_file,

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import os
 import time
 import requests
 import jwt
+import re
 
 gh_priv_key = os.environ['GH_PRIV_KEY']
 logging.basicConfig(level=logging.INFO)
@@ -82,7 +83,7 @@ def checktodo_main():
             elif current_file is not None \
                     and current_pos is not None \
                     and line.startswith('+'):
-                if 'todo' in line.lower():
+                if re.match(r'[^\w\d]todo[^\w\d]', line.lower()):
                     added.append({
                         'line': current_pos,
                         'file': current_file,

--- a/main.py
+++ b/main.py
@@ -83,7 +83,7 @@ def checktodo_main():
             elif current_file is not None \
                     and current_pos is not None \
                     and line.startswith('+'):
-                if re.match(r'[^\w\d]todo(?![\w\d])', line.lower()):
+                if re.match(r'([^\w\d]|^)todo(?![\w\d])', line.lower()):
                     added.append({
                         'line': current_pos,
                         'file': current_file,


### PR DESCRIPTION
The current approach (using a simple `todo` search in a line) will cause it to match with any line containing a `todo` string, also thing like `mastodon` or `ectodomain`. Switching it to a regular expression allows for a check that this is a single word, surrounded by non-word characters.